### PR TITLE
✂️ Extract fields for error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         issue-number: 1
     - name: Assert
       run: |
-        test '${{ steps.get-issue-id.outputs.issue-id }}' = 'Repository does not found.'
+        test '${{ steps.get-issue-id.outputs.error }}' = 'Repository does not found.'
   test-issue-not-found:
     name: Issue not found
     runs-on: ubuntu-latest
@@ -49,4 +49,4 @@ jobs:
         issue-number: -1
     - name: Assert
       run: |
-        test '${{ steps.get-issue-id.outputs.issue-id }}' = 'Issue does not found.'
+        test '${{ steps.get-issue-id.outputs.error }}' = 'Issue does not found.'

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,10 @@ inputs:
 outputs:
   issue-id:
     description: 'Issue Id that can be obtained.'
-    value: ${{ steps.get-issue-id.outputs.result }}
+    value: ${{ steps.get-issue-id.outputs.issue-id }}
+  error:
+    description: 'Error message.'
+    value: ${{ steps.get-issue-id.outputs.error }}
 runs:
   using: "composite"
   steps:
@@ -60,11 +63,11 @@ runs:
           }
 
           if (!result.repository) {
-            return 'Repository does not found.';
+            return '::set-output name=error::Repository does not found.';
           }
 
           if (!result.repository.issue) {
-            return 'Issue does not found.';
+            return '::set-output name=error::Issue does not found.';
           }
 
-          return result.repository.issue.id;
+          return '::set-output name=issue-id::' + result.repository.issue.id;

--- a/action.yml
+++ b/action.yml
@@ -63,11 +63,14 @@ runs:
           }
 
           if (!result.repository) {
-            return '::set-output name=error::Repository does not found.';
+            core.setOutput('error', 'Repository does not found.');
+            return;
           }
 
           if (!result.repository.issue) {
-            return '::set-output name=error::Issue does not found.';
+            core.setOutput('error', 'Issue does not found.');
+            return;
           }
 
-          return '::set-output name=issue-id::' + result.repository.issue.id;
+          core.setOutput('issue-id', result.repository.issue.id);
+          return;


### PR DESCRIPTION
- 目的に応じて outputs の中身を分割する
- github-script で名前付きアウトプットを行うには `core.setOutput(name, value)` を利用する必要がある